### PR TITLE
Change the settings for time for buses to stop

### DIFF
--- a/planner/src/main/java/BusPlanner.java
+++ b/planner/src/main/java/BusPlanner.java
@@ -23,7 +23,9 @@ public class BusPlanner {
         double sigmaOverMu = 1.05;
         int costPerBus = 0;
         int maxRideMinutes = 90;
-        int secondsPerStudent = 15;
+        int secondsPerStudentAtStop = 10; // For students over the first, per stop
+        int secondsPerStudentAtSchool = 10; // Time to unload each student at their school
+        int secondsPerStop = 45;
         int studentsPerBus = 62;
         int studentsPerStop = 10;
 
@@ -35,7 +37,9 @@ public class BusPlanner {
         Plan.COST_PER_BUS = costPerBus;
         Plan.MAX_RIDE_MINUTES = maxRideMinutes;
         Plan.NO_TIERING = true;
-        Plan.SECONDS_PER_STUDENT = secondsPerStudent;
+        Plan.SECONDS_PER_STUDENT_AT_STOP = secondsPerStudentAtStop;
+        Plan.SECONDS_PER_STUDENT_AT_SCHOOL = secondsPerStudentAtSchool;
+        Plan.SECONDS_PER_STOP = secondsPerStop;
         Plan.SIGMA_OVER_MU = sigmaOverMu;
         Plan.SIGMAS = sigmas;
         Plan.STUDENTS_PER_BUS = studentsPerBus;

--- a/planner/src/main/java/Plan.java
+++ b/planner/src/main/java/Plan.java
@@ -31,7 +31,9 @@ import com.azavea.Node;
 public class Plan implements Serializable {
     public static int COST_PER_BUS;
     public static int MAX_RIDE_MINUTES;
-    public static int SECONDS_PER_STUDENT;
+    public static int SECONDS_PER_STUDENT_AT_SCHOOL;
+    public static int SECONDS_PER_STUDENT_AT_STOP;
+    public static int SECONDS_PER_STOP;
     public static int STUDENTS_PER_BUS;
     public static int STUDENTS_PER_STOP;
     public static double SIGMA_OVER_MU;

--- a/planner/src/main/java/School.java
+++ b/planner/src/main/java/School.java
@@ -62,8 +62,15 @@ public class School extends SourceOrSink {
 
             if (current instanceof Stop) { // Stop
                 Stop stop = (Stop)current;
+                time += Plan.SECONDS_PER_STOP;
+                boolean firstStudent = true;
                 for (Student kid : stop.getStudentList()) {
-                    time += Plan.SECONDS_PER_STUDENT;
+                    if(firstStudent) {
+                      firstStudent = false;
+                    } else {
+                      time += Plan.SECONDS_PER_STUDENT_AT_STOP;
+                    }
+
                     kids.add(kid);
                 }
             }
@@ -80,7 +87,7 @@ public class School extends SourceOrSink {
                         newKids.add(kid);
                     }
                     else { // kids delivered
-                        time += Plan.SECONDS_PER_STUDENT;
+                        time += Plan.SECONDS_PER_STUDENT_AT_SCHOOL;
                     }
                 }
                 kids = newKids;


### PR DESCRIPTION
Changed to:
- Each stop is 45 seconds baseline, for a single student
- Each additional student at the stop past the first, add 10 seconds.

This also separates the timings for picking students up from stops and dropping students off at schools. The latter is set to the same value, but separating them out could eliminate confusion and allow us to differentiate the values in the future.