### PR TITLE
Update student stop matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Generate a CSV of stops within a mile radius of each student, e.g.
 
 Back in the sbt console, otp project, find the walk distances for ech student to nearby bus stops
 
-`run ./cost_matrix_nodes.csv ./student_nodes.csv ./student_candidate_stops.csv ./graph_withStudents.obj ./student_stop_eleigibility`
+`run ./cost_matrix_nodes.csv ./student_nodes.csv ./student_candidate_stops.csv ./graph_withStudents.obj ./student_stop_eligibility.ser ./student_stop_eligibility.csv`
 
 Select the `GenerateStudentToStopMatrix` option when prompted. 
 

--- a/open-trip-planner/src/main/scala/com/azavea/busplan/routing/FileInput.scala
+++ b/open-trip-planner/src/main/scala/com/azavea/busplan/routing/FileInput.scala
@@ -62,7 +62,7 @@ object FileInput {
 
   def parseStudentInfo(row: CSVRecord): Map[String, (Int, String)] = {
     val record = row.asScala.toList
-    val info = (record(1).toInt, record(4))
+    val info = (record(1).toInt, record(6))
     Map(record(0) -> info)
   }
 

--- a/open-trip-planner/src/main/scala/com/azavea/busplan/routing/GenerateStudentToStopMatrix.scala
+++ b/open-trip-planner/src/main/scala/com/azavea/busplan/routing/GenerateStudentToStopMatrix.scala
@@ -18,7 +18,8 @@ object GenerateStudentToStopMatrix {
    * @param args(1) Student nodes csv
    * @param args(2) Eligible stops csv
    * @param args(3) Graph w/o highway access
-   * @param args(4) Path to output csv
+   * @param args(4) Path to output .ser file
+   * @param args(5) Path to output csv
    */
   def main(args: Array[String]): Unit = {
     val stopToLocation = FileInput.readNodes(args(0))
@@ -31,9 +32,11 @@ object GenerateStudentToStopMatrix {
       studentToLocation, walkRouter)
     Serialization.write(args(4), results)
     val studentToInfo = FileInput.readStudentInfo(args(1))
-    StudentToStopRouting.createStudentToStopCSV("/home/azavea/files/da_customer/bus_routing/data-wrangling/student-to-stop/eligibility/eligibility-25.csv", results, 1320, studentToInfo)
-    StudentToStopRouting.createStudentToStopCSV("/home/azavea/files/da_customer/bus_routing/data-wrangling/cost-matrix/student-stop-eligibility-40.csv", results, 2112, studentToInfo)
-    StudentToStopRouting.createStudentToStopCSV("/home/azavea/files/da_customer/bus_routing/data-wrangling/cost-matrix/student-stop-eligibility-50.csv", results, 2640, studentToInfo)
-    StudentToStopRouting.createStudentToStopCSV("/home/azavea/files/da_customer/bus_routing/data-wrangling/cost-matrix/student-stop-eligibility-100.csv", results, 5280, studentToInfo)
+    val baseFileName = args(5).split("\\.")(0)
+
+    StudentToStopRouting.createStudentToStopCSV(baseFileName + "-25.csv", results, 1320, studentToInfo)
+    StudentToStopRouting.createStudentToStopCSV(baseFileName + "-40.csv", results, 2112, studentToInfo)
+    StudentToStopRouting.createStudentToStopCSV(baseFileName + "-50.csv", results, 2640, studentToInfo)
+    StudentToStopRouting.createStudentToStopCSV(baseFileName + "-100.csv", results, 5280, studentToInfo)
   }
 }

--- a/open-trip-planner/src/main/scala/com/azavea/busplan/routing/StudentToStopRouting.scala
+++ b/open-trip-planner/src/main/scala/com/azavea/busplan/routing/StudentToStopRouting.scala
@@ -17,13 +17,19 @@ object StudentToStopRouting {
     val bw = new BufferedWriter(csv)
     for ((k, v) <- results) {
       bw.write(k)
-      val newMaxDistance = getMaxDistance(maxDistance, studentToInfo(k)._1)
-      val eligibleStops = getStopsBelowThreshold(v, newMaxDistance)
-      for (stop <- eligibleStops) {
-        bw.write("," + stop)
+      if (v(0)._2 >= 7920) {
+        bw.write("," + v(0)._1)
+        bw.newLine()
+        bw.flush()
+      } else {
+        val newMaxDistance = getMaxDistance(maxDistance, studentToInfo(k)._1)
+        val eligibleStops = getStopsBelowThreshold(v, newMaxDistance)
+        for (stop <- eligibleStops) {
+          bw.write("," + stop)
+        }
+        bw.newLine()
+        bw.flush()
       }
-      bw.newLine()
-      bw.flush()
     }
   }
 


### PR DESCRIPTION
Update process of matching students to stops that they are eligible to be picked up at. For students currently further than a mile and a half from their assigned stop, only make them eligible to be picked up at the stop that they are already at.

Additionally:

- Parameterize basepath for output csv in GenerateStudentToStopMatrix Main method
- Update README to reflect this change