### PR TITLE
Include Return-Garage In Output Route CSV

### DIFF
--- a/planner/src/main/java/Plan.java
+++ b/planner/src/main/java/Plan.java
@@ -58,7 +58,7 @@ public class Plan implements Serializable {
 
             if (bus.equals("dummy")) continue; // Dummy route
 
-	    if (bus.getNext() == null) continue; // Empty route
+            if (bus.getNext() == null) continue; // Empty route
 
             routeWriter.write("" + i);
             while (current != null) {

--- a/planner/src/main/java/Plan.java
+++ b/planner/src/main/java/Plan.java
@@ -56,7 +56,9 @@ public class Plan implements Serializable {
         for (Bus bus : busList) {
             SourceOrSinkOrAnchor current = bus;
 
-            if (bus.equals("dummy")) continue;
+            if (bus.equals("dummy")) continue; // Dummy route
+
+	    if (bus.getNext() == null) continue; // Empty route
 
             routeWriter.write("" + i);
             while (current != null) {
@@ -70,7 +72,7 @@ public class Plan implements Serializable {
                     assignmentWriter.write("\n");
                 }
             }
-            routeWriter.write("\n");
+            routeWriter.write("," + bus.getNode().getUuid() + "\n");
             i++;
         }
 


### PR DESCRIPTION
Return-garages are now included in output route CSVs.  Empty routes are now not printed (instead of printing just a garage UUID [or just two garage UUIDs as would be the case after this PR]).

@simonkassel Please let me know if the above meets your needs.

Resolves https://github.com/azavea/bus-plan/issues/49