### PR TITLE
fix bug that caused students to be routed on highway

### DIFF
--- a/open-trip-planner/src/main/scala/com/azavea/busplan/routing/RouteGenerator.scala
+++ b/open-trip-planner/src/main/scala/com/azavea/busplan/routing/RouteGenerator.scala
@@ -65,9 +65,9 @@ class RouteGenerator(withStudentGraph: Graph, withoutStudentGraph: Graph,
 
   def checkForStudents(start: Node, end: Node): Boolean = {
     if (start.garage || end.garage) {
-      true
-    } else {
       false
+    } else {
+      true
     }
   }
 


### PR DESCRIPTION
Simple swapping of boolean values in RouteGenerator.scala. Make sure that buses with students will avoid the highway.