### PR TITLE
Revert "Include Return-Garage In Output Route CSV"

### DIFF
--- a/planner/src/main/java/Plan.java
+++ b/planner/src/main/java/Plan.java
@@ -56,9 +56,7 @@ public class Plan implements Serializable {
         for (Bus bus : busList) {
             SourceOrSinkOrAnchor current = bus;
 
-            if (bus.equals("dummy")) continue; // Dummy route
-
-            if (bus.getNext() == null) continue; // Empty route
+            if (bus.equals("dummy")) continue;
 
             routeWriter.write("" + i);
             while (current != null) {
@@ -72,7 +70,7 @@ public class Plan implements Serializable {
                     assignmentWriter.write("\n");
                 }
             }
-            routeWriter.write("," + bus.getNode().getUuid() + "\n");
+            routeWriter.write("\n");
             i++;
         }
 


### PR DESCRIPTION
Reverts azavea/bus-plan#50

Because of #25, it's better for the analytics code to read in the route chain without the last garage; reverting.

This also reverts the change that prevented empty routes from being outputted, which the analytic code can also handle.